### PR TITLE
Update header.php

### DIFF
--- a/www/components/header.php
+++ b/www/components/header.php
@@ -14,12 +14,12 @@
 
         <ul class="nav nav-tabs">
             <li class="nav-item">
-                <a class="nav-link <?= $config['moviesActive'] ? 'active' : ''; ?>" href="/movies.php?<?= buildQueryString([], [
+                <a class="nav-link <?= $config['moviesActive'] ? 'active' : ''; ?>" href="/SER322-FinalProject-master/SER322-FinalProject-master/www/movies.php?<?= buildQueryString([], [
                     'm', 'p', 'r'
                 ]) ?>">Movies</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link <?= $config['professionalsActive'] ? 'active' : ''; ?>" href="/professionals.php?<?= buildQueryString([], [
+                <a class="nav-link <?= $config['professionalsActive'] ? 'active' : ''; ?>" href="/SER322-FinalProject-master/SER322-FinalProject-master/www/professionals.php?<?= buildQueryString([], [
                     'm', 'p', 'r'
                 ]) ?>">Professionals</a>
             </li>


### PR DESCRIPTION
Before the change, when the 'Movies' link was clicked, the page would navigate to 
localhost/movies.php (which doesn't exist) but should navigate to 
localhost/SER322-FinalProject-master/SER322-FinalProject-master/www/movies.php

same with the 'Professionals' link except it would navigate to 
localhost/professionals.php rather than
localhost/SER322-FinalProject-master/SER322-FinalProject-master/www/professionals.php